### PR TITLE
Add Python and PHP code examples

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "angular-bootstrap": "~0.12.0",
     "angular-ui-router": "~0.2.0",
     "angular-sanitize": "~1.3.14",
+    "angular-highlightjs": "~0.7.1",
     "jquery": "~2.1.3",
     "ng-ovh": "#cfaade1d00146c2225fd1df7878e5187f6be6bd4",
     "lodash": "~3.5.0",

--- a/build.config.js
+++ b/build.config.js
@@ -68,6 +68,7 @@ module.exports = {
       'vendor/angular-sanitize/angular-sanitize.js',
       'vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
       'vendor/angular-ui-router/release/angular-ui-router.js',
+      'vendor/angular-highlightjs/angular-highlightjs.js',
       'vendor/URIjs/src/URI.js',
       'vendor/ng-ovh/ng-ovh.js',
       'vendor/scrollup/dist/jquery.scrollUp.min.js',

--- a/src/app/api/api.js
+++ b/src/app/api/api.js
@@ -14,7 +14,7 @@
  */
 angular.module( 'consoleApp' )
 
-.config(function config( $stateProvider ) {
+.config(function config( $stateProvider, hljsServiceProvider ) {
   $stateProvider.state( 'main', {
     url: '/',
     views: {
@@ -24,6 +24,11 @@ angular.module( 'consoleApp' )
       }
     },
     data:{ pageTitle: 'Home' }
+  });
+
+  hljsServiceProvider.setOptions({
+      // replace tab with 4 spaces
+      tabReplace: '    '
   });
 });
 

--- a/src/app/api/api.service.js
+++ b/src/app/api/api.service.js
@@ -62,12 +62,10 @@ angular.module('consoleApp').service('Api', function ($rootScope, $q, Ovh) {
 
     // Build code samples
     function buildCodeExamples(subApi) {
-        // console.log("Building code examples for "+subApi.operation.httpMethod+" "+subApi.path);
-
         // POC: build python code sample
         var examples = {
-            'python': {name: "Python", code: "print 'Hello Python'"},
-            'php':    {name: "PHP",    code: "Hello PHP world!"},
+            'python': {name: "Python", code: "print 'Hello Python !'"},
+            'php':    {name: "PHP",    code: "echo 'Hello PHP';"},
         };
 
         subApi.examples = examples;

--- a/src/app/api/api.service.js
+++ b/src/app/api/api.service.js
@@ -1,4 +1,4 @@
-angular.module('consoleApp').service('Api', function ($q, Ovh) {
+angular.module('consoleApp').service('Api', function ($rootScope, $q, Ovh) {
     'use strict';
 
     // You can hide APIs: just add its path into this array:
@@ -60,6 +60,19 @@ angular.module('consoleApp').service('Api', function ($q, Ovh) {
 
     }
 
+    // Build code samples
+    function buildCodeExamples(subApi) {
+        // console.log("Building code examples for "+subApi.operation.httpMethod+" "+subApi.path);
+
+        // POC: build python code sample
+        var examples = {
+            'python': {name: "Python", code: "print 'Hello Python'"},
+            'php':    {name: "PHP",    code: "Hello PHP world!"},
+        };
+
+        subApi.examples = examples;
+    }
+
     this.getSubApis = function (path) {
         return Ovh.getSchema(path).then(function (subApi) {
 
@@ -83,13 +96,24 @@ angular.module('consoleApp').service('Api', function ($q, Ovh) {
                         // check operation params
                         parseParameters(subApi, operation.parameters);
 
-                        // Here it is
-                        subApiList.push({
+                        // build subApiRoute
+                        var subApiRoute = {
                             path        : api.path,
                             description : api.description,
-                            operation   : operation
-                        });
+                            operation   : operation,
+                            examples    : {},
+                        };
 
+                        // initial code sample build
+                        buildCodeExamples(subApiRoute);
+
+                        // watch for parameter changes and update the code
+                        $rootScope.$watch(function() {return operation;}, function(operation, oldOperation) {
+                            buildCodeExamples(subApiRoute);
+                        }, true);
+
+                        // Here it is
+                        subApiList.push(subApiRoute);
                     });
 
                 });

--- a/src/app/api/api.service.js
+++ b/src/app/api/api.service.js
@@ -204,10 +204,8 @@ angular.module('consoleApp').service('Api', function ($rootScope, $q, Ovh) {
         _.forEach(subApi.operation.parameters, function (param) {
             if (param.paramType === 'path' && param.value) {
                 path = path.replace('{' + param.name + '}', encodeURIComponent(param.value));
+                delete parameters.params[param.name];
             }
-
-            // Prune URI param from the param list: already handled
-            delete parameters.params[param.name];
         });
 
         // Build Python

--- a/src/app/api/api.service.js
+++ b/src/app/api/api.service.js
@@ -346,7 +346,7 @@ angular.module('consoleApp').service('Api', function ($rootScope, $q, Ovh) {
                 var paramValue = getRequestParamValue(_param);
 
                 // If the value evaluates to false, prune it, unless it is mandatory or explicitely marked as null by the user
-                if (paramValue || _param.required || _param.inputMode !== 'input') {
+                if (paramValue || paramValue === false || param.required || (param.inputMode !== 'input' && param.inputMode !== undefined)) {
                     ret[_param.name] = paramValue;
                 }
             });
@@ -375,7 +375,7 @@ angular.module('consoleApp').service('Api', function ($rootScope, $q, Ovh) {
             }
 
             // If the value evaluates to false, prune it, unless it is mandatory or explicitely marked as null by the user
-            if (paramValue || param.required || param.inputMode !== 'input') {
+            if (paramValue || paramValue === false || param.required || (param.inputMode !== 'input' && param.inputMode !== undefined)) {
                 if (!config[paramCategory]) {
                     config[paramCategory] = {};
                 }

--- a/src/app/api/api.simpleType.tpl.html
+++ b/src/app/api/api.simpleType.tpl.html
@@ -14,14 +14,14 @@
         <div data-ng-if="!param.isModel">
 
             <!-- value required -->
-            <input type="text" name="{{param.name}}" id="{{param.name}}" class="form-control input-sm"
+            <input type="{{ param.dataType === 'long' ? 'number' : 'text' }}" name="{{param.name}}" id="{{param.name}}" class="form-control input-sm"
                    data-ng-if="param.required"
                    data-ng-model="param.value"
                    required />
 
             <!-- else, can be undefined, null, empty string -->
             <div data-ng-if="!param.required" class="input-group" data-ng-init="param.inputMode = 'input';">
-                <input type="text" name="{{param.name}}" id="{{param.name}}" class="form-control input-sm"
+                <input type="{{ param.dataType === 'long' ? 'number' : 'text' }}" name="{{param.name}}" id="{{param.name}}" class="form-control input-sm"
                        data-ng-disabled="param.inputMode !== 'input'" placeholder="{{ param.inputMode !== 'input' ? param.inputMode : '' }}"
                        data-ng-model="param.value"
                        data-ng-change="checkUndefined(param)" />
@@ -30,7 +30,8 @@
                     <ul class="dropdown-menu dropdown-menu-right" role="menu">
                         <li><a href="" data-ng-click="param.inputMode = 'input'; param.value = undefined; param.dropdownOpen = false;">Input</a></li>
                         <li><a href="" data-ng-click="param.inputMode = 'null';  param.value = null;      param.dropdownOpen = false;"><i>null</i></a></li>
-                        <li><a href="" data-ng-click="param.inputMode = 'empty'; param.value = '';        param.dropdownOpen = false;"><i>empty string</i></a></li>
+                        <li data-ng-if="param.dataType !== 'long'"><a href="" data-ng-click="param.inputMode = 'empty'; param.value = ''; param.dropdownOpen = false;"><i>empty string</i></a></li>
+                        <li data-ng-if="param.dataType === 'long'"><a href="" data-ng-click="param.inputMode = 'zero'; param.value = 0; param.dropdownOpen = false;"><i>Zero</i></a></li>
                     </ul>
                 </div>
             </div>

--- a/src/app/api/api.tpl.html
+++ b/src/app/api/api.tpl.html
@@ -179,7 +179,7 @@
                                     </tab>
 
                                     <tab heading="{{example.name}}" ng-repeat="(language, example) in subApi.examples">
-                                        <pre>{{example.code}}</pre>
+                                        <div hljs hljs-language="{{language}}" source="example.code"></div>
                                     </tab>
                                 </tabset>
 

--- a/src/app/api/api.tpl.html
+++ b/src/app/api/api.tpl.html
@@ -177,6 +177,10 @@
                                             </table>
                                         </div>
                                     </tab>
+
+                                    <tab heading="{{example.name}}" ng-repeat="(language, example) in subApi.examples">
+                                        <pre>{{example.code}}</pre>
+                                    </tab>
                                 </tabset>
 
                             </div>

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -4,6 +4,7 @@ angular.module( 'consoleApp', [
   'ui.router',
   'templates-app',
   'templates-common',
+  'hljs',
   'ngOvh'
 ])
 

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,11 @@
     <!-- font awesome from BootstrapCDN -->
     <!-- <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet"> -->
 
+    <!-- POC: to vendor -->
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/styles/github.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.9.1/highlight.min.js"></script>
+    <!-- /POC -->
+
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400' rel='stylesheet' type='text/css'>
 
     <!-- compiled CSS --><% styles.forEach( function ( file ) { %>


### PR DESCRIPTION
This is a first PR from this week's Hackathon. This PR adds code generation, based on what's done on https://api.ovh.com/console with a couple of nice additions:

- It generates valid code (Yes, that's a feature, hum, hum)
- It supports arbitrarily nested structures
- It brings syntax highlighting, making the current production code look... terribly old
- It only generates required arguments
- It supports all json types (lists will be in a future PR to keep things clean)

I'm definitively NOT a js developer. Although I'd be glad if this PR is accepted as-is, I'd be even happier with an in-depth review, especially regarding modules organization and lib vendoring.